### PR TITLE
Add source maps and vscode debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "command": "npm start",
+      "name": "run npm start",
+      "request": "launch",
+      "type": "node-terminal"
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "launch in chrome",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "target": "ES5",
     "esModuleInterop": true,
-    "jsx": "react"
+    "jsx": "react",
+    "sourceMap": true
   }
 }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -27,4 +27,5 @@ module.exports = {
       directory: path.join(__dirname, "dist"),
     },
   },
+  devtool: "eval-source-map",
 };


### PR DESCRIPTION
Adds `.vscode/launch.json` with two launch configurations. 
- `run npm start` runs our start script in a debug terminal, so use this to start the dev server. this will allow binding of breakpoints and for the program to be exposed in the debug panel of vscode
- `launch in chrome` opens a chrome instance to the open session. you should also be able to just launch from the notification inside vscode or typing the address into any browser.

Also adds the necessary config to generate source maps.